### PR TITLE
입출력 장치 선택 기능을 추가합니다.

### DIFF
--- a/ToneFlow/ToneFlow/Source/View/AudioChannelView.swift
+++ b/ToneFlow/ToneFlow/Source/View/AudioChannelView.swift
@@ -30,6 +30,12 @@ struct AudioChannelView: View {
     // 기기 선택 버튼 텍스트
     var deviceName: String
     
+    // 사용 가능한 장치 목록
+    var availableDevices: [String] = []
+    
+    // 장치 선택 콜백
+    var onDeviceSelected: ((String) -> Void)?
+    
     var body: some View {
         VStack(spacing: 0) {
             // 미터와 노브를 포함하는 HStack
@@ -43,12 +49,25 @@ struct AudioChannelView: View {
                 }
             }
             
-            // 기기 선택 버튼
-            Button {
-
-            } label: {
+            // 기기 선택 메뉴
+            if type == .input {
+                Menu {
+                    ForEach(availableDevices, id: \.self) { device in
+                        Button(device) {
+                            onDeviceSelected?(device)
+                        }
+                    }
+                } label: {
+                    Text(deviceName)
+                        .modifier(deviceSelectButtonModifier)
+                }
+            } else {
                 Text(deviceName)
-                    .modifier(deviceSelectButtonModifier)
+                    .tfFont(.t6(.medium))
+                    .bold()
+                    .foregroundStyle(.gray800)
+                    .lineLimit(1)
+                    .padding(.vertical, 10)
             }
         }
         .onAppear {
@@ -101,7 +120,11 @@ struct AudioChannelView: View {
         AudioChannelView(
             type: .input,
             audioChannelValue: .constant(0.5),
-            deviceName: "US 1x2 HR"
+            deviceName: "US 1x2 HR",
+            availableDevices: ["US 1x2 HR", "맥북 내장 마이크", "에어팟 프로"],
+            onDeviceSelected: { deviceName in
+                print("선택된 입력 장치: \(deviceName)")
+            }
         )
         
         // 출력 채널 미리보기

--- a/ToneFlow/ToneFlow/Source/View/ContentView.swift
+++ b/ToneFlow/ToneFlow/Source/View/ContentView.swift
@@ -36,7 +36,11 @@ struct ContentView: View {
                     AudioChannelView(
                         type: .input,
                         audioChannelValue: $audioChannelViewModel.inputChannelValue,
-                        deviceName: audioChannelViewModel.currentInputDeviceName
+                        deviceName: audioChannelViewModel.currentInputDeviceName,
+                        availableDevices: audioChannelViewModel.availableInputDevices,
+                        onDeviceSelected: {
+                            audioChannelViewModel.updateInputDevice(withName: $0)
+                        }
                     )
                     Spacer()
                     AudioChannelView(

--- a/ToneFlow/ToneFlow/Source/View/ContentView.swift
+++ b/ToneFlow/ToneFlow/Source/View/ContentView.swift
@@ -1,10 +1,7 @@
 import SwiftUI
 
-struct ContentView: View {
-    @ObservedObject var audioManager = AudioManager.shared
-    
-    @State var inputChannelValue: Double = 0.5
-    @State var outputChannelValue: Double = 0.5
+struct ContentView: View {    
+    @StateObject private var audioChannelViewModel = AudioChannelViewModel()
     
     @State var compressorKnobValue: Double = 0.5
     @State var overdriveKnobValue: Double = 0.5
@@ -38,14 +35,14 @@ struct ContentView: View {
                 HStack {
                     AudioChannelView(
                         type: .input,
-                        audioChannelValue: $inputChannelValue,
-                        deviceName: "US 1x2 HR"
+                        audioChannelValue: $audioChannelViewModel.inputChannelValue,
+                        deviceName: audioChannelViewModel.currentInputDeviceName
                     )
                     Spacer()
                     AudioChannelView(
                         type: .output,
-                        audioChannelValue: $outputChannelValue,
-                        deviceName: "~~`s AirPod Pro2"
+                        audioChannelValue: $audioChannelViewModel.outputChannelValue,
+                        deviceName: audioChannelViewModel.currentOutputDeviceName
                     )
                 }
                 .padding(.horizontal, 40)

--- a/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
+++ b/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
@@ -22,32 +22,30 @@ class AudioChannelViewModel: ObservableObject {
     @Published var currentInputDeviceName: String = ""
     @Published var currentOutputDeviceName: String = ""
     
-    // 사용 가능한 디바이스 목록
-    @Published var availableInputDevices: [AVAudioSessionPortDescription] = []
-    @Published var availableOutputDevices: [AVAudioSessionPortDescription] = []
+    // 사용 가능한 입력 장치 목록
+    @Published var availableInputDevices: [String] = []
     
     init(audioManager: AudioManager = AudioManager.shared) {
         self.audioManager = audioManager
         bindAudioManager()
     }
     
+    func updateInputDevice(withName name: String) {
+        audioManager.selectInputDevice(withName: name)
+    }
+    
     private func bindAudioManager() {
-        audioManager.currentInputDeviceName.sink { [weak self] name in
-            self?.currentInputDeviceName = name
+        audioManager.currentInputDevice.sink { [weak self] device in
+            self?.currentInputDeviceName = device.map(\.portName) ?? "알 수 없음"
         }.store(in: &cancellables)
         
-        audioManager.currentOutputDeviceName.sink { [weak self] name in
-            self?.currentOutputDeviceName = name
+        audioManager.currentOutputDevice.sink { [weak self] device in
+            self?.currentOutputDeviceName = device.map(\.portName) ?? "알 수 없음"
         }.store(in: &cancellables)
         
         audioManager.availableInputDevices.sink { [weak self] devices in
-            self?.availableInputDevices = devices
-        }.store(in: &cancellables)
-        
-        audioManager.availableOutputDevices.sink { [weak self] devices in
-            self?.availableOutputDevices = devices
+            self?.availableInputDevices = devices.map(\.portName)
         }.store(in: &cancellables)
     }
-    
 }
 

--- a/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
+++ b/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  AudioChannelViewModel.swift
+//  ToneFlow
+//
+//  Created by YoungK on 4/14/25.
+//
+
+import SwiftUI
+import Combine
+import AVFoundation
+
+class AudioChannelViewModel: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+
+    private let audioManager: AudioManager
+    
+    // 채널 값 (노브 및 미터 표시에 사용)
+    @Published var inputChannelValue: Double = 0.5
+    @Published var outputChannelValue: Double = 0.5
+    
+    // 선택된 디바이스 정보
+    @Published var currentInputDeviceName: String = ""
+    @Published var currentOutputDeviceName: String = ""
+    
+    // 사용 가능한 디바이스 목록
+    @Published var availableInputDevices: [AVAudioSessionPortDescription] = []
+    @Published var availableOutputDevices: [AVAudioSessionPortDescription] = []
+    
+    init(audioManager: AudioManager = AudioManager.shared) {
+        self.audioManager = audioManager
+        bindAudioManager()
+    }
+    
+    private func bindAudioManager() {
+        audioManager.currentInputDeviceName.sink { [weak self] name in
+            self?.currentInputDeviceName = name
+        }.store(in: &cancellables)
+        
+        audioManager.currentOutputDeviceName.sink { [weak self] name in
+            self?.currentOutputDeviceName = name
+        }.store(in: &cancellables)
+        
+        audioManager.availableInputDevices.sink { [weak self] devices in
+            self?.availableInputDevices = devices
+        }.store(in: &cancellables)
+        
+        audioManager.availableOutputDevices.sink { [weak self] devices in
+            self?.availableOutputDevices = devices
+        }.store(in: &cancellables)
+    }
+    
+}
+


### PR DESCRIPTION
## 주요 변경 사항

### AudioChannelViewModel 추가
메인 화면에 컴포넌트들이 많아서 ViewModel을 분리할 예정입니다.

### AudioManager 입출력 장치 관련 로직 추가
- 출력 장치는 시스템에서 관할하여 앱에서 변경할 수 없음.
- 입력 장치 변경 시 `AudioEngine` 을 다시 재생하도록 함.

- AudioManager 초기화(initialize) 시, 사용가능한 입력 장치의 첫번째 장치로 설정하도록 함.

### AudioManager 로그 추가

- 사용가능한 입력 장치가 변경될 때, 사용가능한 입력 장치 목록과 현재 라우트 정보를 출력하도록 함.

- 더 좋은 트리거가 없나 고민..


## 참고사항



## 스크린샷

| 입력 장치만 선택 가능 | 출력 장치는 선택 X |
|--------|--------|
| ![IMG_4710](https://github.com/user-attachments/assets/579a99ba-dfe4-4aaf-b95f-8a3117a9c594) | ![IMG_4711](https://github.com/user-attachments/assets/26ca09fd-b5b6-4167-8e52-0b695dd1b654) | 


