### PR TITLE
입력 게인과 출력 볼륨을 조절 기능 추가 및 MVVM 단방향 플로우 적용

### DIFF
--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
@@ -24,11 +24,11 @@ final class AudioEnvrionment {
         audioSessionManager.currentOutputPublisher
     }
     
-    var currentInputGain: AnyPublisher<Float, Never> {
-        audioSessionManager.currentnputGainPublisher
+    var currentInputGainPublisher: AnyPublisher<Float, Never> {
+        audioSessionManager.currentInputGainPublisher
     }
     
-    var currentOutputVolume: AnyPublisher<Float, Never> {
+    var currentOutputVolumePublisher: AnyPublisher<Float, Never> {
         audioSessionManager.currentOutputVolumePublisher
     }
     

--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
@@ -53,4 +53,12 @@ final class AudioEnvrionment {
             return false
         }
     }
+    
+    func setInputGain(_ gain: Float) throws {
+        try audioSessionManager.setInputGain(gain)
+    }
+    
+    func setOutputVolume(_ volume: Float) {
+        audioSessionManager.setOutputVolume(volume)
+    }
 }

--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioEnvrionment.swift
@@ -24,6 +24,14 @@ final class AudioEnvrionment {
         audioSessionManager.currentOutputPublisher
     }
     
+    var currentInputGain: AnyPublisher<Float, Never> {
+        audioSessionManager.currentnputGainPublisher
+    }
+    
+    var currentOutputVolume: AnyPublisher<Float, Never> {
+        audioSessionManager.currentOutputVolumePublisher
+    }
+    
     private init(audioSessionManager: AudioSessionManageable, audioEngineManager: AudioEngineManageable, isMock: Bool) {
         self.audioSessionManager = audioSessionManager
         self.audioEngineManager = audioEngineManager

--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
@@ -24,7 +24,7 @@ final class AudioSessionManager: AudioSessionManageable {
             .eraseToAnyPublisher()
     }
     
-    var currentnputGainPublisher: AnyPublisher<Float, Never> {
+    var currentInputGainPublisher: AnyPublisher<Float, Never> {
         AVAudioSession.sharedInstance().publisher(for: \.inputGain).eraseToAnyPublisher()
     }
     

--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
@@ -4,6 +4,7 @@ import Combine
 final class AudioSessionManager: AudioSessionManageable {
     private var cancellables = Set<AnyCancellable>()
     private let session = AVAudioSession.sharedInstance()
+    private let systemVolumeController = SystemVolumeController()
     
     var availableInputsPublisher: AnyPublisher<[AudioPortDescription], Never> {
         routeChangePublisher
@@ -39,5 +40,13 @@ final class AudioSessionManager: AudioSessionManageable {
         ])
         try? session.setActive(true)
         try? session.setInputGain(0.5)
+    }
+    
+    func setInputGain(_ gain: Float) throws {
+        try session.setInputGain(gain)
+    }
+    
+    func setOutputVolume(_ volume: Float) {
+        systemVolumeController.setVolume(volume)
     }
 }

--- a/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/AudioSessionManager.swift
@@ -24,6 +24,14 @@ final class AudioSessionManager: AudioSessionManageable {
             .eraseToAnyPublisher()
     }
     
+    var currentnputGainPublisher: AnyPublisher<Float, Never> {
+        AVAudioSession.sharedInstance().publisher(for: \.inputGain).eraseToAnyPublisher()
+    }
+    
+    var currentOutputVolumePublisher: AnyPublisher<Float, Never> {
+        AVAudioSession.sharedInstance().publisher(for: \.outputVolume).eraseToAnyPublisher()
+    }
+    
     init() {
         setupAudioSession()
     }

--- a/ToneFlow/ToneFlow/Source/Model/Implement/SystemVolumeController.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Implement/SystemVolumeController.swift
@@ -1,0 +1,18 @@
+//
+//  SystemVolumeController.swift
+//  ToneFlow
+//
+//  Created by YoungK on 4/17/25.
+//
+
+import UIKit
+import MediaPlayer
+
+final class SystemVolumeController {
+    private let volumeView = MPVolumeView(frame: .zero)
+
+    func setVolume(_ value: Float) {
+        let slider = volumeView.subviews.first(where: { $0 is UISlider }) as? UISlider
+        slider?.value = value
+    }
+}

--- a/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
@@ -11,7 +11,7 @@ protocol AudioSessionManageable {
     var availableInputsPublisher: AnyPublisher<[AudioPortDescription], Never> { get }
     var currentInputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
     var currentOutputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
-    var currentnputGainPublisher: AnyPublisher<Float, Never> { get }
+    var currentInputGainPublisher: AnyPublisher<Float, Never> { get }
     var currentOutputVolumePublisher: AnyPublisher<Float, Never> { get }
     
     func setInputGain(_ gain: Float) throws

--- a/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
@@ -11,6 +11,8 @@ protocol AudioSessionManageable {
     var availableInputsPublisher: AnyPublisher<[AudioPortDescription], Never> { get }
     var currentInputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
     var currentOutputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
+    var currentnputGainPublisher: AnyPublisher<Float, Never> { get }
+    var currentOutputVolumePublisher: AnyPublisher<Float, Never> { get }
     
     func setInputGain(_ gain: Float) throws
     func setOutputVolume(_ volume: Float)

--- a/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Interface/AudioSessionManageable.swift
@@ -11,4 +11,12 @@ protocol AudioSessionManageable {
     var availableInputsPublisher: AnyPublisher<[AudioPortDescription], Never> { get }
     var currentInputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
     var currentOutputPublisher: AnyPublisher<AudioPortDescription?, Never> { get }
+    
+    func setInputGain(_ gain: Float) throws
+    func setOutputVolume(_ volume: Float)
+}
+
+extension AudioSessionManageable {
+    func setInputGain(_ gain: Float) throws {}
+    func setOutputVolume(_ volume: Float) {}
 }

--- a/ToneFlow/ToneFlow/Source/Model/Testing/MockAudioSessionManager.swift
+++ b/ToneFlow/ToneFlow/Source/Model/Testing/MockAudioSessionManager.swift
@@ -8,12 +8,16 @@
 import AVFAudio
 import Combine
 
-final class MockAudioSessionManager: AudioSessionManageable {
+final class MockAudioSessionManager: AudioSessionManageable {    
     let availableInputsPublisher: AnyPublisher<[AudioPortDescription], Never>
     
     let currentInputPublisher: AnyPublisher<AudioPortDescription?, Never>
     
     let currentOutputPublisher: AnyPublisher<AudioPortDescription?, Never>
+    
+    let currentInputGainPublisher: AnyPublisher<Float, Never>
+    
+    let currentOutputVolumePublisher: AnyPublisher<Float, Never>
     
     init() {
         availableInputsPublisher = Just([
@@ -24,6 +28,10 @@ final class MockAudioSessionManager: AudioSessionManageable {
         currentInputPublisher = Just(MockAudioPortDescription(name: "Mock Input 1", identifier: "1", port: .builtInMic)).eraseToAnyPublisher()
         
         currentOutputPublisher = Just(MockAudioPortDescription(name: "Mock Output 1", identifier: "10", port: .builtInSpeaker)).eraseToAnyPublisher()
+        
+        currentInputGainPublisher = Just(0.5).eraseToAnyPublisher()
+        
+        currentOutputVolumePublisher = Just(0.5).eraseToAnyPublisher()
     }
 
 }

--- a/ToneFlow/ToneFlow/Source/View/ContentView.swift
+++ b/ToneFlow/ToneFlow/Source/View/ContentView.swift
@@ -33,21 +33,9 @@ struct ContentView: View {
         ScrollView {
             VStack(spacing: 20) {
                 HStack {
-                    AudioChannelView(
-                        type: .input,
-                        audioChannelValue: $audioChannelViewModel.inputChannelValue,
-                        deviceName: audioChannelViewModel.currentInputDeviceName,
-                        availableDevices: audioChannelViewModel.availableInputDevices,
-                        onDeviceSelected: {
-                            audioChannelViewModel.updateInputDevice(withName: $0)
-                        }
-                    )
+                    AudioChannelView(viewModel: audioChannelViewModel, type: .input)
                     Spacer()
-                    AudioChannelView(
-                        type: .output,
-                        audioChannelValue: $audioChannelViewModel.outputChannelValue,
-                        deviceName: audioChannelViewModel.currentOutputDeviceName
-                    )
+                    AudioChannelView(viewModel: audioChannelViewModel, type: .output)
                 }
                 .padding(.horizontal, 40)
                 .padding(.top, 15)

--- a/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
+++ b/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
@@ -9,16 +9,26 @@ import SwiftUI
 import Combine
 import AVFoundation
 
-class AudioChannelViewModel: ObservableObject {
+final class AudioChannelViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     private let audioEnvrionment: AudioEnvrionment
     
-    // 채널 값 (노브 및 미터 표시에 사용)
-    @Published var inputChannelValue: Double = 0.5
-    @Published var outputChannelValue: Double = 0.5
+    // MARK: - Action
+
+    enum Action {
+        case selectInputDevice(String)
+        case changedInputKnobValue(Double)
+        case changedOutputKnobValue(Double)
+    }
+
+    // MARK: - State
     
-    // 선택된 디바이스 정보
+    // 볼륨을 숫자로 표시 ("0 ~ 100")
+    @Published var inputGainText: String = ""
+    @Published var outputVolumeText: String = ""
+    
+    // 선택된 장치 이름 ("iPhone 마이크")
     @Published var currentInputDeviceName: String = ""
     @Published var currentOutputDeviceName: String = ""
     
@@ -27,44 +37,63 @@ class AudioChannelViewModel: ObservableObject {
     
     init(audioEnvrionment: AudioEnvrionment = AudioEnvrionment.shared) {
         self.audioEnvrionment = audioEnvrionment
-        bindAudioEnvrionment()
-        bindAction()
+        bindState()
     }
     
-    func updateInputDevice(withName name: String) {
+    func send(_ action: Action) {
+        switch action {
+        case .selectInputDevice(let deviceName):
+            updateInputDevice(deviceName)
+        
+        case .changedInputKnobValue(let value):
+            updateInputGain(value)
+        
+        case .changedOutputKnobValue(let value):
+            updateOutputVolume(value)
+        }
+    }
+    
+    private func updateInputDevice(_ name: String) {
         audioEnvrionment.setPreferredInput(name: name)
     }
     
-    func setInputGain(_ gain: Float) {
+    private func updateInputGain(_ gain: Double) {
+        let gain = Float(gain)
         try? audioEnvrionment.setInputGain(gain)
     }
     
-    func setOutputVolume(_ volume: Float) {
+    private func updateOutputVolume(_ volume: Double) {
+        let volume = Float(volume)
         audioEnvrionment.setOutputVolume(volume)
     }
     
-    private func bindAction() {
-        $inputChannelValue.map { Float($0) }.sink { [weak self] value in
-            self?.setInputGain(value)
-        }.store(in: &cancellables)
+    private func bindState() {
+        audioEnvrionment.currentInputDevicePublisher
+            .map { $0?.name ?? "알 수 없음" }
+            .assign(to: \.currentInputDeviceName, on: self)
+            .store(in: &cancellables)
         
-        $outputChannelValue.map { Float($0) }.sink { [weak self] value in
-            self?.setOutputVolume(value)
-        }.store(in: &cancellables)
-    }
-    
-    private func bindAudioEnvrionment() {
-        audioEnvrionment.currentInputDevicePublisher.sink { [weak self] device in
-            self?.currentInputDeviceName = device.map(\.name) ?? "알 수 없음"
-        }.store(in: &cancellables)
+        audioEnvrionment.currentOutputDevicePublisher
+            .map { $0?.name ?? "알 수 없음" }
+            .assign(to: \.currentOutputDeviceName, on: self)
+            .store(in: &cancellables)
         
-        audioEnvrionment.currentOutputDevicePublisher.sink { [weak self] device in
-            self?.currentOutputDeviceName = device.map(\.name) ?? "알 수 없음"
-        }.store(in: &cancellables)
+        audioEnvrionment.availableInputDevicesPublisher
+            .map { $0.map(\.name) }
+            .assign(to: \.availableInputDevices, on: self)
+            .store(in: &cancellables)
         
-        audioEnvrionment.availableInputDevicesPublisher.sink { [weak self] devices in
-            self?.availableInputDevices = devices.map(\.name)
-        }.store(in: &cancellables)
+        audioEnvrionment.currentInputGainPublisher
+            .map { $0 * 100 }
+            .map { String(Int($0)) }
+            .assign(to: \.inputGainText, on: self)
+            .store(in: &cancellables)
+        
+        audioEnvrionment.currentOutputVolumePublisher
+            .map { $0 * 100 }
+            .map { String(Int($0)) }
+            .assign(to: \.outputVolumeText, on: self)
+            .store(in: &cancellables)
     }
 }
 

--- a/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
+++ b/ToneFlow/ToneFlow/Source/ViewModel/AudioChannelViewModel.swift
@@ -28,10 +28,29 @@ class AudioChannelViewModel: ObservableObject {
     init(audioEnvrionment: AudioEnvrionment = AudioEnvrionment.shared) {
         self.audioEnvrionment = audioEnvrionment
         bindAudioEnvrionment()
+        bindAction()
     }
     
     func updateInputDevice(withName name: String) {
         audioEnvrionment.setPreferredInput(name: name)
+    }
+    
+    func setInputGain(_ gain: Float) {
+        try? audioEnvrionment.setInputGain(gain)
+    }
+    
+    func setOutputVolume(_ volume: Float) {
+        audioEnvrionment.setOutputVolume(volume)
+    }
+    
+    private func bindAction() {
+        $inputChannelValue.map { Float($0) }.sink { [weak self] value in
+            self?.setInputGain(value)
+        }.store(in: &cancellables)
+        
+        $outputChannelValue.map { Float($0) }.sink { [weak self] value in
+            self?.setOutputVolume(value)
+        }.store(in: &cancellables)
     }
     
     private func bindAudioEnvrionment() {


### PR DESCRIPTION
## 주요 작업 내용

### 입출력 레벨 조절 기능 추가
- SystemVolumeController를 도입하여 MPVolumeView를 활용한 시스템 출력 볼륨 제어 구현
- AudioEnvironment, AudioSessionManager에 input gain 및 output volume 제어 메서드 추가

### 입출력 레벨 퍼블리셔 추가
- 현재 input gain과 output volume 상태를 구독할 수 있는 Combine 퍼블리셔 제공
- AudioChannelViewModel에서 상태 변화에 따른 UI 갱신 가능

### AudioChannelView MVVM 단방향 플로우 적용
- View 에서 `viewModel.send(:Action)` 메소드를 통해 이벤트를 전달 ->
- 모델에서 비즈니스 로직 수행 -> 
- ViewModel 내 `@Published` 로 구현된 상태 변경 -> 
- View에서 상태 관찰 후 갱신

## 참고사항

Output Volume은 iOS 시스템 정책 상 앱에서 직접 설정할 수 없으나,
MPVolumeView를 통해 우회적으로 조절할 수 있습니다.

currentRoute.inputGain 과 currentRoute.outputVolume 은 5단위로 방출됨


## 스크린샷

![ScreenRecording_04-17-2025 21-46-51_1](https://github.com/user-attachments/assets/6fe621d8-c0f0-4142-a9c4-532744b28bd3)